### PR TITLE
feat: Enhance Mapper navigation with intelligent path comparison and color differentiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Free MyBatis Tool Changelog
 
+## [2.2.3]
+- Enhanced the display of Mapper navigation: When multiple mapper files with the same name exist in different folders, the intelligent path comparison and color differentiation make navigation more intuitive and clear.（优化了Mapper跳转功能的显示效果，不同文件夹下有多个相同的mapper文件时，通过智能路径对比和颜色区分，让导航更直观清晰）
+
+
 ## [2.2.2]
 
 ### Fixed

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,11 @@ version = properties("pluginVersion").get()
 
 // Configure project's dependencies
 repositories {
+    maven("https://maven.aliyun.com/repository/public")
+    // 阿里云镜像（Google Android 相关库）
+    maven("https://maven.aliyun.com/repository/google")
+    // 阿里云镜像（Gradle 插件仓库）
+    maven("https://maven.aliyun.com/repository/gradle-plugin")
     mavenCentral()
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,11 +18,6 @@ version = properties("pluginVersion").get()
 
 // Configure project's dependencies
 repositories {
-    maven("https://maven.aliyun.com/repository/public")
-    // 阿里云镜像（Google Android 相关库）
-    maven("https://maven.aliyun.com/repository/google")
-    // 阿里云镜像（Gradle 插件仓库）
-    maven("https://maven.aliyun.com/repository/gradle-plugin")
     mavenCentral()
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ pluginGroup = com.mozt.plugins
 pluginName = Free MyBatis Tool
 pluginRepositoryUrl = https://github.com/moztl/Free-Mybatis-Tool
 # SemVer format -> https://semver.org
-pluginVersion = 2.2.2
+pluginVersion = 2.2.3
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.

--- a/src/main/java/com/tianlei/mybatis/provider/MapperLineMarkerProvider.java
+++ b/src/main/java/com/tianlei/mybatis/provider/MapperLineMarkerProvider.java
@@ -47,16 +47,16 @@ public class MapperLineMarkerProvider extends RelatedItemLineMarkerProvider {
             Collection<IdDomElement> results = processor.getResults();
             if (!results.isEmpty()) {
                 NavigationGutterIconBuilder<PsiElement> builder = NavigationGutterIconBuilder
-                    .create(Icons.MAPPER_LINE_MARKER_ICON)
-                    .setTargets(Collections2.transform(results, FUN))
-                    .setTooltipText("Navigate to Mapper XML")
-                    .setPopupTitle("Select Target Mapper")
-                    .setCellRenderer(new MapperCellRenderer());
+                        .create(Icons.MAPPER_LINE_MARKER_ICON)
+                        .setTargets(Collections2.transform(results, FUN))
+                        .setTooltipText("Navigate to Mapper XML")
+                        .setPopupTitle("Select Target Mapper")
+                        .setCellRenderer(new MapperCellRenderer());
                 result.add(builder.createLineMarkerInfo(((PsiNameIdentifierOwner) element).getNameIdentifier()));
             }
         }
     }
-    
+
     private static class MapperCellRenderer extends PsiElementListCellRenderer<PsiElement> {
         // 保存所有文件的路径，用于比较
         private static final List<String> allPaths = new ArrayList<>();
@@ -64,23 +64,23 @@ public class MapperLineMarkerProvider extends RelatedItemLineMarkerProvider {
         private static final Map<String, List<PathSegment>> pathDifferenceCache = new HashMap<>();
         // 用于给不同的差异段落分配不同颜色
         private static final Map<String, Integer> segmentColorMap = new HashMap<>();
-        
+
         // 路径段落类，记录路径中的一段文本及其是否为差异部分
         private static class PathSegment {
             String text;
             boolean isDifferent;
             String signature; // 用于颜色一致性的标识
-            
+
             PathSegment(String text, boolean isDifferent, String signature) {
                 this.text = text;
                 this.isDifferent = isDifferent;
                 this.signature = signature;
             }
         }
-        
+
         // 存储每个元素的方法名
         private String currentMethodName = "";
-        
+
         @Override
         public String getElementText(PsiElement element) {
             try {
@@ -89,7 +89,7 @@ public class MapperLineMarkerProvider extends RelatedItemLineMarkerProvider {
                     // 保存方法名以供后续使用
                     String id = xmlTag.getAttributeValue("id");
                     currentMethodName = id != null ? id : "";
-                    return ""; // 返回空字符串，我们将在自定义组件中显示方法名和路径
+                    return ""; // 返回空字符串，在自定义组件中显示方法名和路径
                 }
             } catch (Exception e) {
                 LOGGER.warn("Error getting element text", e);
@@ -107,27 +107,9 @@ public class MapperLineMarkerProvider extends RelatedItemLineMarkerProvider {
                     if (xmlTag.getContainingFile() == null || !(xmlTag.getContainingFile() instanceof XmlFile)) {
                         return null;
                     }
-                    
+
                     XmlFile xmlFile = (XmlFile) xmlTag.getContainingFile();
-                    String fileName = xmlFile.getName();
-                    
-                    // 获取命名空间信息
-                    String namespace = "";
-                    XmlTag rootTag = xmlFile.getRootTag();
-                    if (rootTag != null && "mapper".equals(rootTag.getName())) {
-                        String namespaceAttr = rootTag.getAttributeValue("namespace");
-                        if (namespaceAttr != null && !namespaceAttr.isEmpty()) {
-                            namespace = " [" + namespaceAttr + "]";
-                        }
-                    }
-                    
-                    // 获取方法名（标签ID）
-                    String methodName = "";
-                    String id = xmlTag.getAttributeValue("id");
-                    if (id != null && !id.isEmpty()) {
-                        methodName = id + " - ";
-                    }
-                    
+
                     // 安全获取文件路径
                     String relativePath = "";
                     VirtualFile virtualFile = xmlFile.getVirtualFile();
@@ -148,7 +130,7 @@ public class MapperLineMarkerProvider extends RelatedItemLineMarkerProvider {
                         } else {
                             relativePath = virtualFilePath;
                         }
-                        
+
                         // 添加到路径列表，用于后续比较差异
                         synchronized (allPaths) {
                             if (!allPaths.contains(relativePath)) {
@@ -159,8 +141,8 @@ public class MapperLineMarkerProvider extends RelatedItemLineMarkerProvider {
                             }
                         }
                     }
-                    
-                    // 返回路径（不包含命名空间）
+
+                    // 返回路径
                     return relativePath;
                 }
             } catch (Exception e) {
@@ -173,90 +155,90 @@ public class MapperLineMarkerProvider extends RelatedItemLineMarkerProvider {
         protected int getIconFlags() {
             return 0;
         }
-        
+
         @Override
         public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
             // 移除默认的中间和右侧组件
             removeAll();
             setLayout(new BorderLayout());
-            
+
             // 设置背景色
-            setBackground(isSelected ? 
-                UIUtil.getListSelectionBackground(true) : 
-                UIUtil.getListBackground());
-            
+            setBackground(isSelected ?
+                    UIUtil.getListSelectionBackground(true) :
+                    UIUtil.getListBackground());
+
             if (value instanceof PsiElement) {
                 PsiElement element = (PsiElement) value;
-                
+
                 // 获取方法名和路径
                 getElementText(element); // 这将设置currentMethodName
                 String containerText = getContainerText(element, "");
-                
+
                 // 创建一个完整的彩色组件来显示方法名和路径
                 SimpleColoredComponent mainComponent = new SimpleColoredComponent();
                 mainComponent.setOpaque(true);
-                mainComponent.setBackground(isSelected ? 
-                    UIUtil.getListSelectionBackground(true) : 
-                    UIUtil.getListBackground());
-                
+                mainComponent.setBackground(isSelected ?
+                        UIUtil.getListSelectionBackground(true) :
+                        UIUtil.getListBackground());
+
                 // 设置图标
                 mainComponent.setIcon(getIcon(element));
-                
+
                 // 添加方法名（如果有）
                 if (!currentMethodName.isEmpty()) {
                     // 方法名使用一个固定的宽度显示，后面跟着路径
-                    mainComponent.append(currentMethodName, 
-                        new SimpleTextAttributes(SimpleTextAttributes.STYLE_BOLD,
-                            isSelected ? UIUtil.getListSelectionForeground(true) : 
-                                    list.getForeground()));
-                    
+                    mainComponent.append(currentMethodName,
+                            new SimpleTextAttributes(SimpleTextAttributes.STYLE_BOLD,
+                                    isSelected ? UIUtil.getListSelectionForeground(true) :
+                                            list.getForeground()));
+
                     // 添加适当的空格，确保路径左对齐
                     mainComponent.append("   ", SimpleTextAttributes.REGULAR_ATTRIBUTES);
                 }
-                
+
                 if (containerText != null && !containerText.isEmpty()) {
                     // 获取路径差异部分
                     List<PathSegment> segments = getPathDifferenceSegments(containerText);
-                    
+
                     // 定义几种颜色用于高亮差异部分
                     Color[] highlightColors = {
-                        new Color(0, 102, 204),    // 蓝色
-                        new Color(51, 153, 102),   // 绿色
-                        new Color(230, 92, 0),     // 橙色
-                        new Color(153, 51, 153),   // 紫色
-                        new Color(204, 0, 0),      // 红色
-                        new Color(0, 153, 153),    // 青色
-                        new Color(0, 51, 102),     // 深蓝色
-                        new Color(102, 0, 102)     // 深紫色
+                            new Color(0, 102, 204),    // 蓝色
+                            new Color(51, 153, 102),   // 绿色
+                            new Color(230, 92, 0),     // 橙色
+                            new Color(153, 51, 153),   // 紫色
+                            new Color(204, 0, 0),      // 红色
+                            new Color(0, 153, 153),    // 青色
+                            new Color(0, 51, 102),     // 深蓝色
+                            new Color(102, 0, 102)     // 深紫色
                     };
-                    
+
                     // 为每个段落应用样式
                     for (PathSegment segment : segments) {
                         if (segment.isDifferent) {
                             // 对差异部分使用不同颜色高亮，确保相同值使用相同颜色
                             int colorIndex = getColorIndexForSegment(segment.signature);
                             Color color = highlightColors[colorIndex % highlightColors.length];
-                            
-                            mainComponent.append(segment.text, 
-                                new SimpleTextAttributes(SimpleTextAttributes.STYLE_BOLD, 
-                                    isSelected ? UIUtil.getListSelectionForeground(true) : color));
+
+                            mainComponent.append(segment.text,
+                                    new SimpleTextAttributes(SimpleTextAttributes.STYLE_BOLD,
+                                            isSelected ? UIUtil.getListSelectionForeground(true) : color));
                         } else {
                             // 非差异部分使用灰色
-                            mainComponent.append(segment.text, 
-                                new SimpleTextAttributes(SimpleTextAttributes.STYLE_PLAIN, 
-                                    isSelected ? UIUtil.getListSelectionForeground(true) : 
-                                            SimpleTextAttributes.GRAYED_ATTRIBUTES.getFgColor()));
+                            mainComponent.append(segment.text,
+                                    new SimpleTextAttributes(SimpleTextAttributes.STYLE_PLAIN,
+                                            isSelected ? UIUtil.getListSelectionForeground(true) :
+                                                    SimpleTextAttributes.GRAYED_ATTRIBUTES.getFgColor()));
                         }
                     }
                 }
-                
+
                 // 添加主组件
                 add(mainComponent, BorderLayout.CENTER);
             }
-            
+
             return this;
         }
-        
+
         /**
          * 为段落获取颜色索引，确保相同内容使用相同颜色
          */
@@ -267,9 +249,10 @@ public class MapperLineMarkerProvider extends RelatedItemLineMarkerProvider {
             }
             return segmentColorMap.get(signature);
         }
-        
+
         /**
          * 获取路径中的差异段落
+         *
          * @param path 当前路径
          * @return 路径段落列表，标记了哪些部分是差异部分
          */
@@ -278,20 +261,20 @@ public class MapperLineMarkerProvider extends RelatedItemLineMarkerProvider {
             if (pathDifferenceCache.containsKey(path)) {
                 return pathDifferenceCache.get(path);
             }
-            
+
             // 创建结果列表
             List<PathSegment> segments = new ArrayList<>();
-            
+
             // 解析实际路径为段落
             String[] folders = path.split("[/\\\\]");
-            
+
             // 如果只有一个路径，则没有比较对象，全部视为非差异
             if (allPaths.size() <= 1) {
                 segments.add(new PathSegment(path, false, "single_path"));
                 pathDifferenceCache.put(path, segments);
                 return segments;
             }
-            
+
             // 找出所有需要比较的路径（不包括当前路径）
             List<String> processedOtherPaths = new ArrayList<>();
             for (String otherPath : allPaths) {
@@ -299,22 +282,22 @@ public class MapperLineMarkerProvider extends RelatedItemLineMarkerProvider {
                     processedOtherPaths.add(otherPath);
                 }
             }
-            
+
             // 实际路径比较
             List<String[]> otherPathFolders = new ArrayList<>();
             for (String otherPath : processedOtherPaths) {
                 otherPathFolders.add(otherPath.split("[/\\\\]"));
             }
-            
+
             // 构建路径段落，标记差异部分
             StringBuilder currentSegment = new StringBuilder();
             boolean isDifferent = false;
             String segmentSignature = "";
-            
+
             // 处理每个文件夹
             for (int i = 0; i < folders.length; i++) {
                 String folder = folders[i];
-                
+
                 // 检查此段是否与其他路径不同
                 boolean different = false;
                 for (String[] otherFolders : otherPathFolders) {
@@ -323,33 +306,33 @@ public class MapperLineMarkerProvider extends RelatedItemLineMarkerProvider {
                         break;
                     }
                 }
-                
+
                 // 如果当前差异状态变化，添加之前的段落并重置
-                if ((different != isDifferent && currentSegment.length() > 0) || 
-                    (different && isDifferent && !folder.equals(segmentSignature))) {
+                if ((different != isDifferent && currentSegment.length() > 0) ||
+                        (different && isDifferent && !folder.equals(segmentSignature))) {
                     segments.add(new PathSegment(currentSegment.toString(), isDifferent, segmentSignature));
                     currentSegment = new StringBuilder();
                     segmentSignature = folder;
                 }
-                
+
                 // 更新当前差异状态
                 isDifferent = different;
                 if (isDifferent) {
                     segmentSignature = folder;
                 }
-                
+
                 // 添加当前文件夹名称和分隔符到当前段落
                 currentSegment.append(folder);
                 if (i < folders.length - 1) {
                     currentSegment.append("/");
                 }
             }
-            
+
             // 添加最后一个段落
             if (currentSegment.length() > 0) {
                 segments.add(new PathSegment(currentSegment.toString(), isDifferent, segmentSignature));
             }
-            
+
             // 缓存结果
             pathDifferenceCache.put(path, segments);
             return segments;

--- a/src/main/java/com/tianlei/mybatis/provider/MapperLineMarkerProvider.java
+++ b/src/main/java/com/tianlei/mybatis/provider/MapperLineMarkerProvider.java
@@ -7,13 +7,15 @@ import com.intellij.codeInsight.daemon.RelatedItemLineMarkerProvider;
 import com.intellij.codeInsight.navigation.NavigationGutterIconBuilder;
 import com.intellij.ide.util.PsiElementListCellRenderer;
 import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.openapi.editor.markup.GutterIconRenderer;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiNameIdentifierOwner;
 import com.intellij.psi.xml.XmlFile;
 import com.intellij.psi.xml.XmlTag;
+import com.intellij.ui.SimpleColoredComponent;
+import com.intellij.ui.SimpleTextAttributes;
 import com.intellij.util.CommonProcessors;
+import com.intellij.util.ui.UIUtil;
 import com.intellij.util.xml.DomElement;
 import com.tianlei.mybatis.dom.model.IdDomElement;
 import com.tianlei.mybatis.service.JavaService;
@@ -22,8 +24,15 @@ import com.tianlei.mybatis.util.JavaUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import javax.swing.*;
+import javax.swing.JList;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class MapperLineMarkerProvider extends RelatedItemLineMarkerProvider {
 
@@ -49,20 +58,43 @@ public class MapperLineMarkerProvider extends RelatedItemLineMarkerProvider {
     }
     
     private static class MapperCellRenderer extends PsiElementListCellRenderer<PsiElement> {
+        // 保存所有文件的路径，用于比较
+        private static final List<String> allPaths = new ArrayList<>();
+        // 缓存已经处理过的路径对应的差异部分
+        private static final Map<String, List<PathSegment>> pathDifferenceCache = new HashMap<>();
+        // 用于给不同的差异段落分配不同颜色
+        private static final Map<String, Integer> segmentColorMap = new HashMap<>();
+        
+        // 路径段落类，记录路径中的一段文本及其是否为差异部分
+        private static class PathSegment {
+            String text;
+            boolean isDifferent;
+            String signature; // 用于颜色一致性的标识
+            
+            PathSegment(String text, boolean isDifferent, String signature) {
+                this.text = text;
+                this.isDifferent = isDifferent;
+                this.signature = signature;
+            }
+        }
+        
+        // 存储每个元素的方法名
+        private String currentMethodName = "";
+        
         @Override
         public String getElementText(PsiElement element) {
             try {
                 if (element instanceof XmlTag) {
                     XmlTag xmlTag = (XmlTag) element;
-                    // 获取标签名称和id属性
+                    // 保存方法名以供后续使用
                     String id = xmlTag.getAttributeValue("id");
-                    String tagName = xmlTag.getName();
-                    return tagName + " - " + (id != null ? id : "");
+                    currentMethodName = id != null ? id : "";
+                    return ""; // 返回空字符串，我们将在自定义组件中显示方法名和路径
                 }
             } catch (Exception e) {
                 LOGGER.warn("Error getting element text", e);
             }
-            return element != null ? element.getText() : "Unknown";
+            return "";
         }
 
         @Nullable
@@ -89,6 +121,13 @@ public class MapperLineMarkerProvider extends RelatedItemLineMarkerProvider {
                         }
                     }
                     
+                    // 获取方法名（标签ID）
+                    String methodName = "";
+                    String id = xmlTag.getAttributeValue("id");
+                    if (id != null && !id.isEmpty()) {
+                        methodName = id + " - ";
+                    }
+                    
                     // 安全获取文件路径
                     String relativePath = "";
                     VirtualFile virtualFile = xmlFile.getVirtualFile();
@@ -99,15 +138,30 @@ public class MapperLineMarkerProvider extends RelatedItemLineMarkerProvider {
                             String projectPath = element.getProject().getBasePath();
                             if (virtualFilePath.startsWith(projectPath)) {
                                 relativePath = virtualFilePath.substring(projectPath.length());
+                                // 删除路径开头的 / 或 \
+                                if (relativePath.startsWith("/") || relativePath.startsWith("\\")) {
+                                    relativePath = relativePath.substring(1);
+                                }
                             } else {
                                 relativePath = virtualFilePath;
                             }
                         } else {
                             relativePath = virtualFilePath;
                         }
+                        
+                        // 添加到路径列表，用于后续比较差异
+                        synchronized (allPaths) {
+                            if (!allPaths.contains(relativePath)) {
+                                allPaths.add(relativePath);
+                                // 当添加新路径时清除缓存，重新计算差异
+                                pathDifferenceCache.clear();
+                                segmentColorMap.clear();
+                            }
+                        }
                     }
                     
-                    return   relativePath;
+                    // 返回路径（不包含命名空间）
+                    return relativePath;
                 }
             } catch (Exception e) {
                 LOGGER.warn("Error getting container text", e);
@@ -118,6 +172,187 @@ public class MapperLineMarkerProvider extends RelatedItemLineMarkerProvider {
         @Override
         protected int getIconFlags() {
             return 0;
+        }
+        
+        @Override
+        public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+            // 移除默认的中间和右侧组件
+            removeAll();
+            setLayout(new BorderLayout());
+            
+            // 设置背景色
+            setBackground(isSelected ? 
+                UIUtil.getListSelectionBackground(true) : 
+                UIUtil.getListBackground());
+            
+            if (value instanceof PsiElement) {
+                PsiElement element = (PsiElement) value;
+                
+                // 获取方法名和路径
+                getElementText(element); // 这将设置currentMethodName
+                String containerText = getContainerText(element, "");
+                
+                // 创建一个完整的彩色组件来显示方法名和路径
+                SimpleColoredComponent mainComponent = new SimpleColoredComponent();
+                mainComponent.setOpaque(true);
+                mainComponent.setBackground(isSelected ? 
+                    UIUtil.getListSelectionBackground(true) : 
+                    UIUtil.getListBackground());
+                
+                // 设置图标
+                mainComponent.setIcon(getIcon(element));
+                
+                // 添加方法名（如果有）
+                if (!currentMethodName.isEmpty()) {
+                    // 方法名使用一个固定的宽度显示，后面跟着路径
+                    mainComponent.append(currentMethodName, 
+                        new SimpleTextAttributes(SimpleTextAttributes.STYLE_BOLD,
+                            isSelected ? UIUtil.getListSelectionForeground(true) : 
+                                    list.getForeground()));
+                    
+                    // 添加适当的空格，确保路径左对齐
+                    mainComponent.append("   ", SimpleTextAttributes.REGULAR_ATTRIBUTES);
+                }
+                
+                if (containerText != null && !containerText.isEmpty()) {
+                    // 获取路径差异部分
+                    List<PathSegment> segments = getPathDifferenceSegments(containerText);
+                    
+                    // 定义几种颜色用于高亮差异部分
+                    Color[] highlightColors = {
+                        new Color(0, 102, 204),    // 蓝色
+                        new Color(51, 153, 102),   // 绿色
+                        new Color(230, 92, 0),     // 橙色
+                        new Color(153, 51, 153),   // 紫色
+                        new Color(204, 0, 0),      // 红色
+                        new Color(0, 153, 153),    // 青色
+                        new Color(0, 51, 102),     // 深蓝色
+                        new Color(102, 0, 102)     // 深紫色
+                    };
+                    
+                    // 为每个段落应用样式
+                    for (PathSegment segment : segments) {
+                        if (segment.isDifferent) {
+                            // 对差异部分使用不同颜色高亮，确保相同值使用相同颜色
+                            int colorIndex = getColorIndexForSegment(segment.signature);
+                            Color color = highlightColors[colorIndex % highlightColors.length];
+                            
+                            mainComponent.append(segment.text, 
+                                new SimpleTextAttributes(SimpleTextAttributes.STYLE_BOLD, 
+                                    isSelected ? UIUtil.getListSelectionForeground(true) : color));
+                        } else {
+                            // 非差异部分使用灰色
+                            mainComponent.append(segment.text, 
+                                new SimpleTextAttributes(SimpleTextAttributes.STYLE_PLAIN, 
+                                    isSelected ? UIUtil.getListSelectionForeground(true) : 
+                                            SimpleTextAttributes.GRAYED_ATTRIBUTES.getFgColor()));
+                        }
+                    }
+                }
+                
+                // 添加主组件
+                add(mainComponent, BorderLayout.CENTER);
+            }
+            
+            return this;
+        }
+        
+        /**
+         * 为段落获取颜色索引，确保相同内容使用相同颜色
+         */
+        private int getColorIndexForSegment(String signature) {
+            if (!segmentColorMap.containsKey(signature)) {
+                // 分配一个新的颜色索引
+                segmentColorMap.put(signature, segmentColorMap.size());
+            }
+            return segmentColorMap.get(signature);
+        }
+        
+        /**
+         * 获取路径中的差异段落
+         * @param path 当前路径
+         * @return 路径段落列表，标记了哪些部分是差异部分
+         */
+        private List<PathSegment> getPathDifferenceSegments(String path) {
+            // 检查缓存中是否已有处理结果
+            if (pathDifferenceCache.containsKey(path)) {
+                return pathDifferenceCache.get(path);
+            }
+            
+            // 创建结果列表
+            List<PathSegment> segments = new ArrayList<>();
+            
+            // 解析实际路径为段落
+            String[] folders = path.split("[/\\\\]");
+            
+            // 如果只有一个路径，则没有比较对象，全部视为非差异
+            if (allPaths.size() <= 1) {
+                segments.add(new PathSegment(path, false, "single_path"));
+                pathDifferenceCache.put(path, segments);
+                return segments;
+            }
+            
+            // 找出所有需要比较的路径（不包括当前路径）
+            List<String> processedOtherPaths = new ArrayList<>();
+            for (String otherPath : allPaths) {
+                if (!otherPath.equals(path)) {
+                    processedOtherPaths.add(otherPath);
+                }
+            }
+            
+            // 实际路径比较
+            List<String[]> otherPathFolders = new ArrayList<>();
+            for (String otherPath : processedOtherPaths) {
+                otherPathFolders.add(otherPath.split("[/\\\\]"));
+            }
+            
+            // 构建路径段落，标记差异部分
+            StringBuilder currentSegment = new StringBuilder();
+            boolean isDifferent = false;
+            String segmentSignature = "";
+            
+            // 处理每个文件夹
+            for (int i = 0; i < folders.length; i++) {
+                String folder = folders[i];
+                
+                // 检查此段是否与其他路径不同
+                boolean different = false;
+                for (String[] otherFolders : otherPathFolders) {
+                    if (i >= otherFolders.length || !folder.equals(otherFolders[i])) {
+                        different = true;
+                        break;
+                    }
+                }
+                
+                // 如果当前差异状态变化，添加之前的段落并重置
+                if ((different != isDifferent && currentSegment.length() > 0) || 
+                    (different && isDifferent && !folder.equals(segmentSignature))) {
+                    segments.add(new PathSegment(currentSegment.toString(), isDifferent, segmentSignature));
+                    currentSegment = new StringBuilder();
+                    segmentSignature = folder;
+                }
+                
+                // 更新当前差异状态
+                isDifferent = different;
+                if (isDifferent) {
+                    segmentSignature = folder;
+                }
+                
+                // 添加当前文件夹名称和分隔符到当前段落
+                currentSegment.append(folder);
+                if (i < folders.length - 1) {
+                    currentSegment.append("/");
+                }
+            }
+            
+            // 添加最后一个段落
+            if (currentSegment.length() > 0) {
+                segments.add(new PathSegment(currentSegment.toString(), isDifferent, segmentSignature));
+            }
+            
+            // 缓存结果
+            pathDifferenceCache.put(path, segments);
+            return segments;
         }
     }
 }

--- a/src/main/java/com/tianlei/mybatis/provider/MapperLineMarkerProvider.java
+++ b/src/main/java/com/tianlei/mybatis/provider/MapperLineMarkerProvider.java
@@ -5,7 +5,7 @@ import com.google.common.collect.Collections2;
 import com.intellij.codeInsight.daemon.RelatedItemLineMarkerInfo;
 import com.intellij.codeInsight.daemon.RelatedItemLineMarkerProvider;
 import com.intellij.codeInsight.navigation.NavigationGutterIconBuilder;
-import com.intellij.ide.util.DefaultPsiElementCellRenderer;
+import com.intellij.ide.util.PsiElementListCellRenderer;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.markup.GutterIconRenderer;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -23,7 +23,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
-import java.awt.*;
 import java.util.Collection;
 
 public class MapperLineMarkerProvider extends RelatedItemLineMarkerProvider {
@@ -43,14 +42,13 @@ public class MapperLineMarkerProvider extends RelatedItemLineMarkerProvider {
                     .setTargets(Collections2.transform(results, FUN))
                     .setTooltipText("Navigate to Mapper XML")
                     .setPopupTitle("Select Target Mapper")
-                    .setCellRenderer(new MapperXmlRenderer());
+                    .setCellRenderer(new MapperCellRenderer());
                 result.add(builder.createLineMarkerInfo(((PsiNameIdentifierOwner) element).getNameIdentifier()));
             }
         }
     }
     
-    // 使用DefaultPsiElementCellRenderer作为基类以避免兼容性问题
-    private static class MapperXmlRenderer extends DefaultPsiElementCellRenderer {
+    private static class MapperCellRenderer extends PsiElementListCellRenderer<PsiElement> {
         @Override
         public String getElementText(PsiElement element) {
             try {
@@ -64,12 +62,12 @@ public class MapperLineMarkerProvider extends RelatedItemLineMarkerProvider {
             } catch (Exception e) {
                 LOGGER.warn("Error getting element text", e);
             }
-            return super.getElementText(element);
+            return element != null ? element.getText() : "Unknown";
         }
 
         @Nullable
         @Override
-        public String getContainerText(PsiElement element, String name) {
+        protected String getContainerText(PsiElement element, String name) {
             try {
                 // 显示文件路径
                 if (element instanceof XmlTag) {
@@ -94,6 +92,7 @@ public class MapperLineMarkerProvider extends RelatedItemLineMarkerProvider {
                     // 安全获取文件路径
                     String relativePath = "";
                     VirtualFile virtualFile = xmlFile.getVirtualFile();
+
                     if (virtualFile != null) {
                         String virtualFilePath = virtualFile.getPath();
                         if (element.getProject() != null && element.getProject().getBasePath() != null) {
@@ -108,18 +107,12 @@ public class MapperLineMarkerProvider extends RelatedItemLineMarkerProvider {
                         }
                     }
                     
-                    return fileName + namespace + (relativePath.isEmpty() ? "" : " - " + relativePath);
+                    return   relativePath;
                 }
             } catch (Exception e) {
                 LOGGER.warn("Error getting container text", e);
             }
-            return super.getContainerText(element, name);
-        }
-
-        @Override
-        public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
-            // 确保调用父类的渲染方法
-            return super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+            return null;
         }
 
         @Override

--- a/src/main/java/com/tianlei/mybatis/provider/MapperLineMarkerProvider.java
+++ b/src/main/java/com/tianlei/mybatis/provider/MapperLineMarkerProvider.java
@@ -5,9 +5,13 @@ import com.google.common.collect.Collections2;
 import com.intellij.codeInsight.daemon.RelatedItemLineMarkerInfo;
 import com.intellij.codeInsight.daemon.RelatedItemLineMarkerProvider;
 import com.intellij.codeInsight.navigation.NavigationGutterIconBuilder;
+import com.intellij.ide.util.DefaultPsiElementCellRenderer;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.markup.GutterIconRenderer;
+import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiNameIdentifierOwner;
+import com.intellij.psi.xml.XmlFile;
 import com.intellij.psi.xml.XmlTag;
 import com.intellij.util.CommonProcessors;
 import com.intellij.util.xml.DomElement;
@@ -16,11 +20,15 @@ import com.tianlei.mybatis.service.JavaService;
 import com.tianlei.mybatis.util.Icons;
 import com.tianlei.mybatis.util.JavaUtils;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+import javax.swing.*;
+import java.awt.*;
 import java.util.Collection;
 
 public class MapperLineMarkerProvider extends RelatedItemLineMarkerProvider {
 
+    private static final Logger LOGGER = Logger.getInstance(MapperLineMarkerProvider.class);
     private static final Function<DomElement, XmlTag> FUN = domElement -> domElement.getXmlTag();
 
     @Override
@@ -30,13 +38,93 @@ public class MapperLineMarkerProvider extends RelatedItemLineMarkerProvider {
             JavaService.getInstance(element.getProject()).process(element, processor);
             Collection<IdDomElement> results = processor.getResults();
             if (!results.isEmpty()) {
-                NavigationGutterIconBuilder<PsiElement> builder =
-                        NavigationGutterIconBuilder.create(Icons.MAPPER_LINE_MARKER_ICON)
-                                .setAlignment(GutterIconRenderer.Alignment.CENTER)
-                                .setTargets(Collections2.transform(results, FUN))
-                                .setTooltipTitle("Navigation to target in mapper xml");
+                NavigationGutterIconBuilder<PsiElement> builder = NavigationGutterIconBuilder
+                    .create(Icons.MAPPER_LINE_MARKER_ICON)
+                    .setTargets(Collections2.transform(results, FUN))
+                    .setTooltipText("Navigate to Mapper XML")
+                    .setPopupTitle("Select Target Mapper")
+                    .setCellRenderer(new MapperXmlRenderer());
                 result.add(builder.createLineMarkerInfo(((PsiNameIdentifierOwner) element).getNameIdentifier()));
             }
+        }
+    }
+    
+    // 使用DefaultPsiElementCellRenderer作为基类以避免兼容性问题
+    private static class MapperXmlRenderer extends DefaultPsiElementCellRenderer {
+        @Override
+        public String getElementText(PsiElement element) {
+            try {
+                if (element instanceof XmlTag) {
+                    XmlTag xmlTag = (XmlTag) element;
+                    // 获取标签名称和id属性
+                    String id = xmlTag.getAttributeValue("id");
+                    String tagName = xmlTag.getName();
+                    return tagName + " - " + (id != null ? id : "");
+                }
+            } catch (Exception e) {
+                LOGGER.warn("Error getting element text", e);
+            }
+            return super.getElementText(element);
+        }
+
+        @Nullable
+        @Override
+        public String getContainerText(PsiElement element, String name) {
+            try {
+                // 显示文件路径
+                if (element instanceof XmlTag) {
+                    XmlTag xmlTag = (XmlTag) element;
+                    if (xmlTag.getContainingFile() == null || !(xmlTag.getContainingFile() instanceof XmlFile)) {
+                        return null;
+                    }
+                    
+                    XmlFile xmlFile = (XmlFile) xmlTag.getContainingFile();
+                    String fileName = xmlFile.getName();
+                    
+                    // 获取命名空间信息
+                    String namespace = "";
+                    XmlTag rootTag = xmlFile.getRootTag();
+                    if (rootTag != null && "mapper".equals(rootTag.getName())) {
+                        String namespaceAttr = rootTag.getAttributeValue("namespace");
+                        if (namespaceAttr != null && !namespaceAttr.isEmpty()) {
+                            namespace = " [" + namespaceAttr + "]";
+                        }
+                    }
+                    
+                    // 安全获取文件路径
+                    String relativePath = "";
+                    VirtualFile virtualFile = xmlFile.getVirtualFile();
+                    if (virtualFile != null) {
+                        String virtualFilePath = virtualFile.getPath();
+                        if (element.getProject() != null && element.getProject().getBasePath() != null) {
+                            String projectPath = element.getProject().getBasePath();
+                            if (virtualFilePath.startsWith(projectPath)) {
+                                relativePath = virtualFilePath.substring(projectPath.length());
+                            } else {
+                                relativePath = virtualFilePath;
+                            }
+                        } else {
+                            relativePath = virtualFilePath;
+                        }
+                    }
+                    
+                    return fileName + namespace + (relativePath.isEmpty() ? "" : " - " + relativePath);
+                }
+            } catch (Exception e) {
+                LOGGER.warn("Error getting container text", e);
+            }
+            return super.getContainerText(element, name);
+        }
+
+        @Override
+        public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+            // 确保调用父类的渲染方法
+            return super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+        }
+
+        @Override
+        protected int getIconFlags() {
+            return 0;
         }
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.tianlei.plugin.mybatis</id>
     <name>Free MyBatis Tool</name>
-    <version>2.2.2</version>
+    <version>2.2.3</version>
     <vendor email="156751282@qq.com" url="https://github.com/moztl/Free-Mybatis-Tool">tianlei</vendor>
     <idea-version since-build="222"/>
     <description>


### PR DESCRIPTION
Enhanced the display of Mapper navigation: When multiple mapper files with the same name exist in different folders, the intelligent path comparison and color differentiation make navigation more intuitive and clear.（优化了Mapper跳转功能的显示效果，不同文件夹下有多个相同的mapper文件时，通过智能路径对比和颜色区分，让导航更直观清晰）

- 优化前的效果
![1](https://github.com/user-attachments/assets/9c4a9842-78a6-4388-a6ab-66e9b1fe93ed)

- 优化后的效果
![2](https://github.com/user-attachments/assets/761cd130-475e-4c71-8673-ec7d4a0174f1)
